### PR TITLE
Refactor Amenity name field to use String instead of Enum

### DIFF
--- a/src/main/java/com/chertiavdev/bookingapp/model/Amenity.java
+++ b/src/main/java/com/chertiavdev/bookingapp/model/Amenity.java
@@ -2,8 +2,6 @@ package com.chertiavdev.bookingapp.model;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,21 +25,9 @@ public class Amenity {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    @Enumerated(EnumType.STRING)
-    private AmenityName name;
+    private String name;
 
     public Amenity(Long id) {
         this.id = id;
-    }
-
-    public enum AmenityName {
-        WIFI,
-        WASHING_MACHINE,
-        BABY_CHANGING,
-        BATHROOM,
-        KITCHEN,
-        PARTY_ROOM,
-        SMOKE_DETECTOR,
-        SWIMMING_POOL
     }
 }


### PR DESCRIPTION
- replaced the AmenityName enum with a simple String field for the `name` property.