### PR TITLE
Update Dockerfile, environment variables, and README:

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,4 +22,4 @@ SCHEDULER_CRON_TIME_ZONE=Europe/Copenhagen
 STRIP_SECRET_KEY=sk_test
 STRIP_CURRENCY=usd
 
-APP.BASE.URL=http://localhost:8080
+APP_BASE_URL=http://localhost:8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-# Builder stage
-FROM openjdk:17-jdk-slim AS builder
+# ----- Builder -----
+FROM openjdk:17.0.1-jdk-slim AS builder
 WORKDIR /application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-# Final stage
-FROM openjdk:17-jdk-slim
+# ----- Runtime -----
+FROM eclipse-temurin:17-jre-jammy
 WORKDIR /application
 COPY --from=builder /application/dependencies/ ./
 COPY --from=builder /application/spring-boot-loader/ ./

--- a/README.md
+++ b/README.md
@@ -230,6 +230,12 @@ After running the application, you can access it via the following endpoints:
 - Base URL: `http://localhost:8080/api`
 - Swagger UI: [http://localhost:8080/api/swagger-ui/index.html](http://localhost:8080/api/swagger-ui/index.html)
 
+#### ☁️ AWS Deployment (public demo)
+- Live Swagger UI: [http://18.194.216.234/api/swagger-ui/index.html](http://18.194.216.234/api/swagger-ui/index.html)
+
+> ⚠️ **Note:** The AWS endpoint is available for demonstration purposes only. Please do not use it to submit sensitive or production-level data.
+
+
 ## 📊 Entity Relationships
 
 The application has the following entities and their relationships:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,7 +22,7 @@ springdoc.default-produces-media-type=application/json
 server.servlet.context-path=/api
 
 # Base URL for the application ((loaded from environment)
-app.base.url=${APP.BASE.URL}
+app.base.url=${APP_BASE_URL}
 
 # JWT expiration time and secret key (loaded from environment)
 jwt.expiration=${JWT_EXPIRATION}


### PR DESCRIPTION
- Use `eclipse-temurin:17-jre-jammy` as runtime image for enhanced compatibility.
- Update environment variable naming from `APP.BASE.URL` to `APP_BASE_URL`.
- Add AWS deployment details in `README.md` with a demo link and cautionary note.
- Improve consistency in Docker stage comments.